### PR TITLE
Add .NET 8 Web API with JWT authentication

### DIFF
--- a/JwtAuthApi/Controllers/AuthController.cs
+++ b/JwtAuthApi/Controllers/AuthController.cs
@@ -1,0 +1,57 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+
+namespace JwtAuthApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly IConfiguration _configuration;
+
+        public AuthController(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        [HttpPost("login")]
+        public IActionResult Login([FromBody] LoginRequest request)
+        {
+            if (request.Username == "user" && request.Password == "password")
+            {
+                var token = GenerateJwtToken(request.Username);
+                return Ok(new { token });
+            }
+
+            return Unauthorized();
+        }
+
+        private string GenerateJwtToken(string username)
+        {
+            var jwtKey = _configuration["Jwt:Key"] ?? "SuperSecretKey";
+            var jwtIssuer = _configuration["Jwt:Issuer"] ?? "JwtAuthApi";
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            var claims = new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, username),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+            };
+
+            var token = new JwtSecurityToken(
+                issuer: jwtIssuer,
+                audience: null,
+                claims: claims,
+                expires: DateTime.UtcNow.AddHours(1),
+                signingCredentials: credentials);
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+    }
+
+    public record LoginRequest(string Username, string Password);
+}

--- a/JwtAuthApi/Controllers/WeatherForecastController.cs
+++ b/JwtAuthApi/Controllers/WeatherForecastController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JwtAuthApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        [HttpGet]
+        [Authorize]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            }).ToArray();
+        }
+    }
+
+    public class WeatherForecast
+    {
+        public DateOnly Date { get; set; }
+        public int TemperatureC { get; set; }
+        public string? Summary { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    }
+}

--- a/JwtAuthApi/JwtAuthApi.csproj
+++ b/JwtAuthApi/JwtAuthApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.1" />
+  </ItemGroup>
+</Project>

--- a/JwtAuthApi/Program.cs
+++ b/JwtAuthApi/Program.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var jwtKey = builder.Configuration["Jwt:Key"] ?? "SuperSecretKey";
+var jwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "JwtAuthApi";
+var keyBytes = Encoding.UTF8.GetBytes(jwtKey);
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = jwtIssuer,
+        IssuerSigningKey = new SymmetricSecurityKey(keyBytes)
+    };
+});
+
+builder.Services.AddAuthorization();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "JwtAuthApi", Version = "v1" });
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "JWT Authorization header using the Bearer scheme."
+    };
+    c.AddSecurityDefinition("Bearer", securityScheme);
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        { securityScheme, new string[] { } }
+    });
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+

--- a/JwtAuthApi/Properties/launchSettings.json
+++ b/JwtAuthApi/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "JwtAuthApi": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/JwtAuthApi/appsettings.json
+++ b/JwtAuthApi/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Jwt": {
+    "Key": "SuperSecretKey",
+    "Issuer": "JwtAuthApi"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # TestProj
-test
+
+This repository contains a sample .NET 8 Web API project that demonstrates JWT authentication.
+
+## Running the API
+
+The `JwtAuthApi` project targets .NET 8.0. You can build and run the API using the `dotnet` CLI:
+
+```bash
+dotnet restore JwtAuthApi/JwtAuthApi.csproj
+dotnet run --project JwtAuthApi/JwtAuthApi.csproj
+```
+
+The API exposes two endpoints:
+
+- `POST /Auth/login` – accepts a JSON body with `username` and `password` and returns a JWT token when the credentials are valid (default user/password is `user`/`password`).
+- `GET /WeatherForecast` – a protected endpoint that requires a valid JWT Bearer token in the `Authorization` header.
+
+Swagger UI is enabled in development to facilitate testing.


### PR DESCRIPTION
## Summary
- create `JwtAuthApi` minimal API project targeting .NET 8
- implement JWT authentication and authorization
- add sample Auth and WeatherForecast controllers
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e8e3f8ad483329a79617fa894b7e4